### PR TITLE
Add issue templates for talk proposal

### DIFF
--- a/.github/ISSUE_TEMPLATE/proposal--featured-talk.md
+++ b/.github/ISSUE_TEMPLATE/proposal--featured-talk.md
@@ -1,0 +1,20 @@
+---
+name: Talk proposal - Feature Talk (max 25 minutes)
+about: Propose a feature talk. Max 25 minutes in length
+title: "Talk proposal: <talk title>"
+labels: Feature
+assignees: ""
+---
+
+# Title of talk
+
+A short description of the talk. The goal should be to explain to people WHY this topic is interesting and HOW it will help them learn decentralized web protocols and tools. 1-2 paragraphs is fine.
+
+Include a short bio--anything that gives us an idea of why you're interested to speak on this subject. Feel free to include any relevant links.
+
+- Name
+- [Twitter]()
+- [Github]()
+- [Website]()
+
+* [ ] I've read and agree to the [ProtoSchool Seattle Code of Conduct](https://github.com/jimcal/seattle/blob/master/CODE_OF_CONDUCT.md)

--- a/.github/ISSUE_TEMPLATE/proposal--featured-talk.md
+++ b/.github/ISSUE_TEMPLATE/proposal--featured-talk.md
@@ -8,13 +8,13 @@ assignees: ""
 
 # Title of talk
 
-A short description of the talk. The goal should be to explain to people WHY this topic is interesting and HOW it will help them learn decentralized web protocols and tools. 1-2 paragraphs is fine.
+A short description of the talk. The goal should be to explain to people WHY this topic is interesting and HOW it will help them learn decentralized web protocols and tools. 1-2 paragraphs is fine. Please avoid the content like product pitches or vendor driven talk. 
 
-Include a short bio--anything that gives us an idea of why you're interested to speak on this subject. Feel free to include any relevant links.
+Include a short bio--anything that gives us an idea of why you're interested to speak on this subject. Feel free to include any relevant links, especially to a video of you speaking if you have one.
 
 - Name
 - [Twitter]()
 - [Github]()
 - [Website]()
 
-* [ ] I've read and agree to the [ProtoSchool Seattle Code of Conduct](https://github.com/jimcal/seattle/blob/master/CODE_OF_CONDUCT.md)
+* [ ] I've read and agree to the [ProtoSchool Seattle Code of Conduct](https://github.com/ProtoSchool/seattle/blob/master/CODE_OF_CONDUCT.md)

--- a/.github/ISSUE_TEMPLATE/proposal--lightning-talk.md
+++ b/.github/ISSUE_TEMPLATE/proposal--lightning-talk.md
@@ -1,0 +1,20 @@
+---
+name: Talk proposal - Lightning Talk (~10 min)
+about: "Propose a short talk that is about 10 minutes in length "
+title: "Talk proposal: <Talk name>"
+labels: Lightning
+assignees: ""
+---
+
+# Title of talk
+
+A short description of the talk. The goal should be to explain to people WHY this topic is interesting and HOW it will help them learn decentralized web protocols and tools. 1-2 paragraphs is fine.
+
+Include a short bio--anything that gives us an idea of why you're interested to speak on this subject. Feel free to include any relevant links.
+
+- Name
+- [Twitter]()
+- [Github]()
+- [Website]()
+
+* [ ] I've read and agree to the [ProtoSchool Seattle Code of Conduct](https://github.com/jimcal/seattle/blob/master/CODE_OF_CONDUCT.md)

--- a/.github/ISSUE_TEMPLATE/proposal--lightning-talk.md
+++ b/.github/ISSUE_TEMPLATE/proposal--lightning-talk.md
@@ -8,13 +8,14 @@ assignees: ""
 
 # Title of talk
 
-A short description of the talk. The goal should be to explain to people WHY this topic is interesting and HOW it will help them learn decentralized web protocols and tools. 1-2 paragraphs is fine.
+A short description of the talk. The goal should be to explain to people WHY this topic is interesting and HOW it will help them learn decentralized web protocols and tools. 1-2 paragraphs is fine. Please avoid the content like product pitches or vendor driven talk. 
 
-Include a short bio--anything that gives us an idea of why you're interested to speak on this subject. Feel free to include any relevant links.
+Include a short bio--anything that gives us an idea of why you're interested to speak on this subject. Feel free to include any relevant links, especially to a video of you speaking if you have one.
 
 - Name
 - [Twitter]()
 - [Github]()
 - [Website]()
 
-* [ ] I've read and agree to the [ProtoSchool Seattle Code of Conduct](https://github.com/jimcal/seattle/blob/master/CODE_OF_CONDUCT.md)
+* [ ] I've read and agree to the [ProtoSchool Seattle Code of Conduct](https://github.com/ProtoSchool/seattle/blob/master/CODE_OF_CONDUCT.md)
+* [ ] I'm new to giving talks and want to practice present to an organizer over a video call first


### PR DESCRIPTION
In order to facilitate the talk proposal process, I added the issue
templates to help community members submit talk proposals. Given we have
2 hrs most meetup, a combination of 2 feature talks or 4 lightning talks
should serve our community well.

Thanks SeattleJS & @Frijol for issue template inspiration.